### PR TITLE
improved algorithm to find the minimum-volume enclosing ellipsoid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - When passing a number to the `pool` keyword argument, the sampler automatically caches the likelihood function in the subprocesses of the multiprocessing pool. This reduces communication between processes and can substantially improve performance.
 - Changed the way ellipsoids are split, preventing rare instances where ellipsoid splitting stops prematurely. (#28)
+- Improved the performance of the algorithm for finding the minimum-volume enclosing ellipsoid.
 
 ### Fixed
 - Fixed a rare freeze when the neural networks predict the same score for all input values. (#27)

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -86,9 +86,7 @@ def test_invert_symmetric_positive_semidefinite_matrix():
         np.linalg.inv(m))
 
 
-@pytest.mark.parametrize("tol", [0, 1])
-def test_minimum_volume_enclosing_ellipsoid(points_on_hypersphere_boundary,
-                                            tol):
+def test_minimum_volume_enclosing_ellipsoid(points_on_hypersphere_boundary):
     # Test that the MVEE algorithm returns a good approximation to the MVEE.
 
     c_true = np.median(points_on_hypersphere_boundary, axis=0)
@@ -99,10 +97,9 @@ def test_minimum_volume_enclosing_ellipsoid(points_on_hypersphere_boundary,
     # first iteration.
     points = np.concatenate([points_on_hypersphere_boundary,
                              np.atleast_2d(c_true + np.random.random() - 0.5)])
-    c, A = minimum_volume_enclosing_ellipsoid(points, tol=tol,
-                                              max_iterations=1000)
-    assert np.allclose(c, c_true, rtol=0, atol=1e-3) or tol > 0
-    assert np.allclose(A, A_true, rtol=0, atol=1e-2) or tol > 0
+    c, A = minimum_volume_enclosing_ellipsoid(points)
+    assert np.allclose(c, c_true, rtol=0, atol=1e-3)
+    assert np.allclose(A, A_true, rtol=0, atol=1e-2)
 
 
 def test_ellipsoid_construction():


### PR DESCRIPTION
The following PR changes the algorithm for finding the minimum-volume enclosing ellipsoid (MVEE). The original algorithm was based on the Khachiyan algorithm. Now, nautilus is using a slightly modified version of this original algorithm that is significantly faster, especially in high dimensions. A downside is that only the original algorithm is mathematically proven to converge to the MVEE. However, in all tests I performed, the results of the new algorithm were basically the same (or better in high dimensions since it could be run longer).