### PR TITLE
Parallelization using Dask cluster.

### DIFF
--- a/nautilus/bounds/neural.py
+++ b/nautilus/bounds/neural.py
@@ -8,7 +8,6 @@ from threadpoolctl import threadpool_limits
 from .basic import Ellipsoid, UnitCubeEllipsoidMixture
 from .union import Union
 from ..neural import NeuralNetworkEmulator
-from ..pool import pool_size
 
 
 class NeuralBound():
@@ -50,8 +49,8 @@ class NeuralBound():
         neural_network_kwargs : dict, optional
             Non-default keyword arguments passed to the constructor of
             MLPRegressor.
-        pool : multiprocessing.Pool, optional
-            Pool used for parallel processing.
+        pool : nautilus.pool.NautilusPool or None, optional
+            Pool used for parallel processing. Default is None.
         rng : None or numpy.random.Generator, optional
             Determines random number generation. Default is None.
 
@@ -237,8 +236,8 @@ class NautilusBound():
         neural_network_kwargs : dict, optional
             Non-default keyword arguments passed to the constructor of
             MLPRegressor.
-        pool : multiprocessing.Pool, optional
-            Pool used for parallel processing.
+        pool : nautilus.pool.NautilusPool or None, optional
+            Pool used for parallel processing. Default is None.
         rng : None or numpy.random.Generator, optional
             Determines random number generation. Default is None.
 
@@ -354,8 +353,8 @@ class NautilusBound():
         return_points : bool, optional
             If True, return sampled points. Otherwise, sample internally until
             at least `n_points` are saved.
-        pool : multiprocessing.Pool, optional
-            Pool used for parallel processing.
+        pool : nautilus.pool.NautilusPool or None, optional
+            Pool used for parallel processing. Default is None.
 
         Returns
         -------
@@ -375,7 +374,7 @@ class NautilusBound():
                     self.n_sample += n_sample
                     self.n_reject += n_sample - len(points)
             else:
-                n_jobs = pool_size(pool)
+                n_jobs = pool.size
                 n_points_per_job = (
                     (max(n_points - len(self.points), 10000)) // n_jobs) + 1
                 func = partial(self._reset_and_sample, n_points_per_job)

--- a/nautilus/neural.py
+++ b/nautilus/neural.py
@@ -92,6 +92,11 @@ class NeuralNetworkEmulator():
 
         if pool is None:
             emulator.neural_networks = list(map(f, range(n_networks)))
+        elif hasattr(pool, 'client'):
+            # Not strictly needed, but the Dask wrapper had a problem when
+            # working from source.
+            tmp = list(pool.client.map(f, range(n_networks)))
+            emulator.neural_networks = pool.client.gather(tmp)
         else:
             emulator.neural_networks = list(pool.map(f, range(n_networks)))
 

--- a/nautilus/neural.py
+++ b/nautilus/neural.py
@@ -92,11 +92,6 @@ class NeuralNetworkEmulator():
 
         if pool is None:
             emulator.neural_networks = list(map(f, range(n_networks)))
-        elif hasattr(pool, 'client'):
-            # Not strictly needed, but the Dask wrapper had a problem when
-            # working from source.
-            tmp = list(pool.client.map(f, range(n_networks)))
-            emulator.neural_networks = pool.client.gather(tmp)
         else:
             emulator.neural_networks = list(pool.map(f, range(n_networks)))
 

--- a/nautilus/pool.py
+++ b/nautilus/pool.py
@@ -56,8 +56,6 @@ class NautilusPool:
             workers.
 
         """
-        if pool is None or pool == 1:
-            self.pool = None
         if isinstance(pool, int):
             self.pool = Pool(pool, initializer=initialize_worker,
                              initargs=(likelihood, ))

--- a/nautilus/pool.py
+++ b/nautilus/pool.py
@@ -55,3 +55,21 @@ def pool_size(pool):
         if hasattr(pool, attr):
             return getattr(pool, attr)
     raise ValueError('Cannot determine size of pool.')
+
+class Dask_pool:
+    """Wrapper for avoiding Dask specific details other
+       places in the code.
+    """
+
+    def __init__(self, client):
+        self.client = client
+    
+    def map(self, f, x):
+        res = self.client.map(f, x)
+        res = self.client.gather(res)
+        
+        return res
+    
+    @property
+    def size(self):
+        return len(self.client.nthreads())

--- a/nautilus/pool.py
+++ b/nautilus/pool.py
@@ -1,5 +1,7 @@
 """Module implementing helper functions for working with pools."""
 
+from multiprocessing import Pool
+
 
 def initialize_worker(likelihood):
     """
@@ -31,45 +33,78 @@ def likelihood_worker(*args):
     return LIKELIHOOD(*args)
 
 
-def pool_size(pool):
+class NautilusPool:
     """
-    Determine the size of a pool, i.e., how many workers it has.
+    Wrapper for avoiding implementation-specific details elsewhere.
 
-    Parameters
+    Attributes
     ----------
-    pool : object
-        The pool object.
-
-    Returns
-    -------
-    size : int
-        The size of the pool.
-
-    Raises
-    ------
-    ValueError
-        If the pool size cannot be determined.
+    pool : object or None
+        Pool used for parallelization.
 
     """
-    for attr in ['_processes', '_max_workers', 'size']:
-        if hasattr(pool, attr):
-            return getattr(pool, attr)
-    raise ValueError('Cannot determine size of pool.')
 
-class Dask_pool:
-    """Wrapper for avoiding Dask specific details other
-       places in the code.
-    """
+    def __init__(self, pool, likelihood=None):
+        """
+        Initialize a pool.
 
-    def __init__(self, client):
-        self.client = client
-    
-    def map(self, f, x):
-        res = self.client.map(f, x)
-        res = self.client.gather(res)
-        
-        return res
-    
+        Parameters
+        ----------
+        pool : object
+            Pool used for parallelization. If a number, initialize a pool
+            from the `multiprocessing` library with the specified number of
+            workers.
+
+        """
+        if pool is None or pool == 1:
+            self.pool = None
+        if isinstance(pool, int):
+            self.pool = Pool(pool, initializer=initialize_worker,
+                             initargs=(likelihood, ))
+        else:
+            self.pool = pool
+
+    def map(self, func, iterable):
+        """
+        Loop a function over an iterable, similar to the built-in map function.
+
+        Parameters
+        ----------
+        func : function
+            Function to use.
+        iterable : object
+            Iterable object such as a list or numpy array.
+
+        Returns
+        -------
+        result : list
+            Result of applying the function to all values in the iterable.
+
+        """
+        if 'distributed.client.Client' in str(type(self.pool)):
+            return list(self.client.gather(self.client.map(func, iterable)))
+        else:
+            return list(self.pool.map(func, iterable))
+
     @property
     def size(self):
-        return len(self.client.nthreads())
+        """Determine the number of workers in the pool.
+
+        Returns
+        -------
+        size : int
+            Size of the pool.
+
+        Raises
+        ------
+        ValueError
+            If the pool size cannot be determined.
+
+
+        """
+        if 'distributed.client.Client' in str(type(self.pool)):
+            return len(self.client.nthreads())
+        for attr in ['_processes', '_max_workers', 'size', 'nt']:
+            if hasattr(self.pool, attr):
+                return getattr(self.pool, attr)
+        raise ValueError('Cannot determine size of pool.')

--- a/nautilus/pool.py
+++ b/nautilus/pool.py
@@ -82,7 +82,7 @@ class NautilusPool:
 
         """
         if 'distributed.client.Client' in str(type(self.pool)):
-            return list(self.client.gather(self.client.map(func, iterable)))
+            return list(self.pool.gather(self.pool.map(func, iterable)))
         else:
             return list(self.pool.map(func, iterable))
 
@@ -103,7 +103,7 @@ class NautilusPool:
 
         """
         if 'distributed.client.Client' in str(type(self.pool)):
-            return len(self.client.nthreads())
+            return len(self.pool.nthreads())
         for attr in ['_processes', '_max_workers', 'size', 'nt']:
             if hasattr(self.pool, attr):
                 return getattr(self.pool, attr)

--- a/nautilus/sampler.py
+++ b/nautilus/sampler.py
@@ -16,7 +16,7 @@ from time import time
 from warnings import warn
 
 from .bounds import UnitCube, NautilusBound
-from .pool import initialize_worker, likelihood_worker, pool_size
+from .pool import initialize_worker, likelihood_worker, pool_size, Dask_pool
 
 
 class Sampler():
@@ -275,6 +275,10 @@ class Sampler():
         self.neural_network_kwargs = neural_network_kwargs
         self.vectorized = vectorized
         self.pass_dict = pass_dict
+
+        # So the user don't need to call the wrapper class.
+        if 'distributed.client.Client' in str(type(pool)):
+            pool = Dask_pool(pool)
 
         try:
             pool = list(pool)

--- a/nautilus/sampler.py
+++ b/nautilus/sampler.py
@@ -16,7 +16,7 @@ from time import time
 from warnings import warn
 
 from .bounds import UnitCube, NautilusBound
-from .pool import initialize_worker, likelihood_worker, pool_size, Dask_pool
+from .pool import initialize_worker, likelihood_worker, NautilusPool
 
 
 class Sampler():
@@ -203,7 +203,9 @@ class Sampler():
             integer, the sampler will use a multiprocessing.Pool object with
             the specified number of processes. Finally, if specifying a tuple,
             the first one specifies the pool used for likelihood calls and the
-            second one the pool for sampler calculations. Default is None.
+            second one the pool for sampler calculations. Supported pools
+            include instances of `multiprocessing.Pool` and
+            `dask.distributed.client.Client`. Default is None.
         seed : None or int, optional
             Seed for random number generation used for reproducible results
             accross different runs. If None, results are not reproducible.
@@ -276,31 +278,25 @@ class Sampler():
         self.vectorized = vectorized
         self.pass_dict = pass_dict
 
-        # So the user don't need to call the wrapper class.
-        if 'distributed.client.Client' in str(type(pool)):
-            pool = Dask_pool(pool)
-
         try:
             pool = list(pool)
         except TypeError:
             pool = [pool]
 
         for i in range(len(pool)):
-            if pool[i] == 1:
+            if pool[i] in [None, 1]:
                 pool[i] = None
-            if isinstance(pool[i], int):
-                if i == 0:
-                    pool[i] = Pool(pool[i], initializer=initialize_worker,
-                                   initargs=(self.likelihood, ))
-                    self.likelihood = likelihood_worker
-                else:
-                    pool[i] = Pool(pool[i])
+            elif i == 0 and isinstance(pool[i], int):
+                pool[i] = NautilusPool(pool[i], likelihood=self.likelihood)
+                self.likelihood = likelihood_worker
+            else:
+                pool[i] = NautilusPool(pool[i])
 
         self.pool_l = pool[0]
         self.pool_s = pool[-1]
 
         if n_batch is None:
-            s = 1 if self.pool_l is None else pool_size(self.pool_l)
+            s = 1 if self.pool_l is None else self.pool_l.size
             n_batch = (100 // s + (100 % s != 0)) * s
         self.n_batch = n_batch
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = ["numpy>=1.18.0", "scipy>=1.4.0", "scikit-learn>=0.22.0",
 
 [project.optional-dependencies]
 checkpointing = ["h5py>=3.0.0"]
-tests = ["h5py>=3.0.0"]
+tests = ["h5py>=3.0.0", "dask[distributed]>=2024.1.0"]
 
 [project.urls]
 Home = "https://nautilus-sampler.readthedocs.io"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = ["numpy>=1.18.0", "scipy>=1.4.0", "scikit-learn>=0.22.0",
 
 [project.optional-dependencies]
 checkpointing = ["h5py>=3.0.0"]
-tests = ["h5py>=3.0.0", "dask[distributed]>=2024.1.0"]
+tests = ["h5py>=3.0.0", "dask[distributed]>=2022.2.0"]
 
 [project.urls]
 Home = "https://nautilus-sampler.readthedocs.io"

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -1,12 +1,12 @@
 import numpy as np
 import pytest
 
-from multiprocessing import Pool
 from scipy.special import gamma
 
 from nautilus import bounds
 from nautilus.bounds.basic import minimum_volume_enclosing_ellipsoid
 from nautilus.bounds.basic import invert_symmetric_positive_semidefinite_matrix
+from nautilus.pool import NautilusPool
 
 
 @pytest.fixture
@@ -403,7 +403,7 @@ def test_nautilus_bound_reset_and_sample(random_points_from_hypercube, n_jobs):
     log_l_min = np.median(log_l)
 
     if n_jobs > 1:
-        pool = Pool(n_jobs)
+        pool = NautilusPool(n_jobs)
     else:
         pool = None
 
@@ -419,7 +419,7 @@ def test_nautilus_bound_reset_and_sample(random_points_from_hypercube, n_jobs):
     volume_2 = nbound.log_v
 
     if n_jobs > 1:
-        pool.close()
+        pool.pool.close()
 
     assert np.all(points_1 == points_2)
     assert volume_1 == volume_2

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -76,6 +76,8 @@ def test_bounds_io(h5py_group, bound_class, rng_sync):
             rng.bit_generator.state = bound_write.rng.bit_generator.state
 
     bound_read = bound_class.read(h5py_group, rng=rng)
+    # Reading a boundary without specifying an RGN shouldn't crash.
+    bound_class.read(h5py_group, rng=None)
 
     if bound_class != NeuralBound:
         assert (np.all(bound_write.sample(10000) == bound_read.sample(10000))

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -1,12 +1,14 @@
-import multiprocessing
 import numpy as np
+import multiprocessing
 import os
 import pytest
 import time
 
 from multiprocessing import Pool
+from dask.distributed import Client
 
 from nautilus import Sampler
+from nautilus.pool import NautilusPool
 
 
 def prior(x):
@@ -20,26 +22,32 @@ def likelihood(x):
 
 @pytest.mark.skipif(multiprocessing.get_start_method() == 'spawn',
                     reason=('pytest does not support spawning'))
-@pytest.mark.parametrize("pool", [1, 2, Pool(2), Pool(3), None,
-                                  (2, 2), (None, 1), (2, Pool(2))])
+@pytest.mark.parametrize("pool", [None, 1, 2, (1, 4), (4, 1), 'mp', 'dask'])
 def test_pool(pool):
     # Test that the expected number of processes are run.
+
+    if isinstance(pool, tuple):
+        n_jobs = pool[0]
+    else:
+        if pool not in ['mp', 'dask']:
+            n_jobs = 1 if pool is None else pool
+        elif pool == 'mp':
+            n_jobs = 4
+            pool = Pool(n_jobs)
+        else:
+            pool = Client()
+            n_jobs = NautilusPool(pool).size
 
     sampler = Sampler(prior, likelihood, n_dim=2, n_live=50, n_networks=1,
                       pool=pool)
     sampler.run(f_live=1.0, n_eff=0)
     points, log_w, log_l, blobs = sampler.posterior(return_blobs=True)
 
-    if isinstance(pool, tuple):
-        pool = pool[0]
-
-    if isinstance(pool, int):
-        n_jobs = pool
-    elif pool is None:
-        n_jobs = 1
-    else:
-        n_jobs = pool._processes
-
     assert len(np.unique(blobs)) == n_jobs
     assert sampler.n_batch >= 100
     assert (sampler.n_batch % n_jobs) == 0
+
+    try:
+        pool.close()
+    except AttributeError:
+        pass


### PR DESCRIPTION
Basic support for paralleling Nautilus on a Dask cluster. Out high-throughput data center is not optimized or well configured for running MPI jobs. We were discussing running cosmological inference using a code, which apparently relies on Nautilus. Wanting to see if we could avoid MPI, I tested parallelising the basic example in the Nautilus documentation.

After creating a Dask cluster:
from dask.distributed import LocalCluster
cluster = LocalCluster()
client = cluster.get_client()

the interface:
sampler = Sampler(prior, likelihood, pass_dict=False, pool=client)

remains unchanged. While the Dask client supports map, the syntax
the Dask versions is asynchronous. To avoid this detail being exposed
too many locations, the code use wrapper to mimic the same behaviour
as the multiprocessing pools.

Testing, all the stages could be parallelized over many machines (not
using the local cluster above, but through the dask-jobqueue package).